### PR TITLE
Direct post fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Fat Zebra WooCommerce Plugin
 ============================
 
-Version 1.5.4 for API Version 1.0
+Version 1.5.5 for API Version 1.0
 
 A WordPress plugin to add Fat Zebra support to [WooCommerce](http://www.woothemes.com/woocommerce/) for Australian Merchants.
 
@@ -19,8 +19,8 @@ Install the plugin
 There are two methods to install the plugin:
 
 **Copy the file to the WordPress plugins directory:**
- 
- 
+
+
  1. Make a new directory in [SITE_ROOT]/wp-content/plugins called fatzebra-woocommerce
  2. Copy the file class-wc-fatzebra.php to this new directory.
  3. Activate the newly installed plugin in the WordPress Plugin Manager.

--- a/class-wc-fatzebra-masterpass.php
+++ b/class-wc-fatzebra-masterpass.php
@@ -8,7 +8,7 @@ function fz_masterpass_init() {
       $this->icon         = "https://www.mastercard.com/mc_us/wallet/img/en/AU/mcpp_wllt_btn_chk_147x034px.png";
       $this->has_fields   = true;
       $this->method_title = __( 'Fat Zebra (MasterPass)', 'woocommerce' );
-      $this->version      = "1.5.1";
+      $this->version      = "1.5.5";
 
       $this->api_version  = "1.0";
       $this->live_url     = "https://gateway.fatzebra.com.au/v{$this->api_version}/purchases";
@@ -38,7 +38,7 @@ function fz_masterpass_init() {
       add_action( 'woocommerce_api_wc_fatzebra_masterpass' , array( $this, 'check_masterpass_response' ) );
     }
 
-    /** 
+    /**
      * Initializes the parent (WC_FatZebra) settings
      */
     function init_parent_settings() {

--- a/class-wc-fatzebra-visacheckout.php
+++ b/class-wc-fatzebra-visacheckout.php
@@ -8,7 +8,7 @@ function fz_visacheckout_init() {
       $this->icon         = "https://assets.secure.checkout.visa.com/VmeCardArts/partner/POS_horizontal_99x34.png";
       $this->has_fields   = true;
       $this->method_title = __( 'Fat Zebra (VISA Checkout)', 'woocommerce' );
-      $this->version      = "1.5.1";
+      $this->version      = "1.5.5";
 
       $this->api_version  = "1.0";
       $this->live_url     = "https://gateway.fatzebra.com.au/v{$this->api_version}/purchases";
@@ -34,7 +34,7 @@ function fz_visacheckout_init() {
       add_action('scheduled_subscription_payment_' . $this->id, array(&$this, 'scheduled_subscription_payment'), 10, 3);
     }
 
-    /** 
+    /**
      * Initializes the parent (WC_FatZebra) settings
      */
     function init_parent_settings() {
@@ -76,7 +76,7 @@ function fz_visacheckout_init() {
               'title' => "Collect Shipping Details",
               'type' => 'checkbox',
               'default' => 'yes'
-            ),  
+            ),
       );
 
     } // End init_form_fields()
@@ -105,7 +105,7 @@ function fz_visacheckout_init() {
       <input type='hidden' name='encPaymentData' id='encPaymentData' />
       <input type='hidden' name='callid' id='callid' value='<?php echo $callid; ?>' />
       <input type='hidden' name='token' id='token' value='<?php echo WC()->session->get('visa_wallet_token'); ?>' />
-      
+
       <p>
         With Visa Checkout, you now have an easier way to pay with your card online, from the company you know and trust. Create an account once and speed through your purchase without re-entering payment or shipping information wherever you see Visa Checkout.
       </p>
@@ -150,7 +150,7 @@ function fz_visacheckout_init() {
             'checkout_captured' => !is_null($callid)
             )
           );
-      wp_enqueue_script( 'fz-visacheckout' );  
+      wp_enqueue_script( 'fz-visacheckout' );
       wp_enqueue_script( 'visa-checkout' );
 
       if ($this->parent_settings['fraud_data'] == 'yes' && $this->parent_settings["fraud_device_id"] === "yes") {
@@ -160,7 +160,7 @@ function fz_visacheckout_init() {
         wp_enqueue_script('fz-io-bb');
       }
 
-      if (!is_null($callid)) { 
+      if (!is_null($callid)) {
         //pre-select Visa Checkout as the payment method
         $available_gateways = WC()->payment_gateways->get_available_payment_gateways();
         $available_gateways['fatzebra_visacheckout']->set_current();
@@ -347,10 +347,10 @@ function fz_visacheckout_init() {
         }
 
         return array(
-          "card_token" => $this->response_data->response->token, 
-          "card_number" => $this->response_data->response->card_number, 
-          "card_expiry" => $this->response_data->response->card_expiry, 
-          "card_holder" => $this->response_data->response->card_holder, 
+          "card_token" => $this->response_data->response->token,
+          "card_number" => $this->response_data->response->card_number,
+          "card_expiry" => $this->response_data->response->card_expiry,
+          "card_holder" => $this->response_data->response->card_holder,
           "transaction_id" => $this->response_data->response->token,
           "wallet" => $this->response_data->response->wallet);
       } catch (Exception $e) {
@@ -516,7 +516,7 @@ function fz_visacheckout_init() {
 
       foreach($keys as $key):
         WC()->session->set($key, null);
-      endforeach; 
+      endforeach;
     }
 
     function get_visa_checkout_button($accepted_cards) {
@@ -600,7 +600,7 @@ function fz_visacheckout_init() {
             'review_message' => 'Please select your card and click Continue to finish your order',
             )
           );
-      wp_enqueue_script( 'fz-visacheckout' );  
+      wp_enqueue_script( 'fz-visacheckout' );
       wp_enqueue_script( 'visa-checkout' );
   }
 
@@ -622,7 +622,7 @@ function fz_visacheckout_init() {
     if (empty($callid)) {
       return $fields;
     }
-    
+
     $token_result = $gw->tokenize_card(array("callid" => $callid));
 
     if (is_wp_error($token_result)) {
@@ -649,7 +649,7 @@ function fz_visacheckout_init() {
     WC()->session->set('visa_wallet_masked_number', $token_result['card_number']);
 
     wc_setcookie('fatzebra_visacheckout_callid', null, time() - 3600);
-    return $fields;    
+    return $fields;
   }
 
   function fz_visacheckout_populate_default_field_value($_, $fieldname) {

--- a/class-wc-fatzebra.php
+++ b/class-wc-fatzebra.php
@@ -222,8 +222,8 @@ function fz_init() {
 
         wp_register_script('fz-direct-post-handler', plugin_dir_url(__FILE__) . '/images/fatzebra.js', array('jquery'), WC_VERSION, true);
         wp_localize_script('fz-direct-post-handler', 'fatzebra', array(
-          'url' => $url, 
-          'return_path' => $return_path, 
+          'url' => $url,
+          'return_path' => $return_path,
           'verification_value' => $verification_value)
         );
         wp_enqueue_script('fz-direct-post-handler');
@@ -247,7 +247,7 @@ function fz_init() {
       global $woocommerce;
 
       if ($this->direct_post_enabled()) {
-        $this->params["card_token"] = $_POST['card_token'];
+        $this->params["card_token"] = $_POST['fatzebra-token'];
       } else {
         $this->params["card_number"] = str_replace(' ', '', $_POST['fatzebra-card-number']);
         if (!isset($_POST["fatzebra-card-number"])) {
@@ -404,7 +404,7 @@ function fz_init() {
 
       $this->params["customer_ip"] = $this->get_customer_real_ip();
       $this->params["currency"] = $order->get_order_currency();
-      
+
       $test_mode = $this->settings['test_mode'] == 'yes';
       $this->params["test"] = $test_mode;
       $sandbox_mode = $this->settings["sandbox_mode"] == "yes"; // Yup, the checkbox settings return as 'yes' or 'no'
@@ -418,7 +418,7 @@ function fz_init() {
       $args = array('method' => 'POST',
                     'body' => $order_text,
                     'headers' => array('Authorization' => 'Basic ' . base64_encode($this->settings["username"] . ":" . $this->settings["token"]),
-                      'X-Test-Mode' => $test_mode, 
+                      'X-Test-Mode' => $test_mode,
                       'User-Agent' => "WooCommerce Plugin " . $this->version),
                     'timeout' => 30);
       try {
@@ -552,11 +552,11 @@ function fz_init() {
       }
 
       $args = array(
-        'method' => 'POST', 
-        'body' => $order_text, 
+        'method' => 'POST',
+        'body' => $order_text,
         'headers' => array(
           'Authorization' => 'Basic ' . base64_encode($this->settings["username"] . ":" . $this->settings["token"]),
-          'X-Test-Mode' => $test_mode, 
+          'X-Test-Mode' => $test_mode,
           'User-Agent' => "WooCommerce Plugin " . $this->version
           ),
         'timeout' => 30
@@ -624,13 +624,13 @@ function fz_init() {
       $order_text = json_encode($payload);
 
       $args = array(
-        'method' => 'POST', 
-        'body' => $order_text, 
+        'method' => 'POST',
+        'body' => $order_text,
         'headers' => array(
           'Authorization' => 'Basic ' . base64_encode($this->settings["username"] . ":" . $this->settings["token"]),
-          'X-Test-Mode' => $test_mode, 
+          'X-Test-Mode' => $test_mode,
           'User-Agent' => "WooCommerce Plugin " . $this->version
-          ), 
+          ),
         'timeout' => 30
         );
       try {
@@ -686,14 +686,14 @@ function fz_init() {
      */
     function get_fraud_customer($order) {
       $data = array(
-        'first_name' => $order->billing_first_name, 
-        'last_name' => $order->billing_last_name, 
-        'email' => $order->billing_email, 
-        'address_1' => $order->billing_address_1, 
-        'address_2' => $order->billing_address_2, 
-        'city' => $order->billing_city, 
-        'country' => $this->country_map[$order->billing_country], 
-        'post_code' => $order->billing_postcode, 
+        'first_name' => $order->billing_first_name,
+        'last_name' => $order->billing_last_name,
+        'email' => $order->billing_email,
+        'address_1' => $order->billing_address_1,
+        'address_2' => $order->billing_address_2,
+        'city' => $order->billing_city,
+        'country' => $this->country_map[$order->billing_country],
+        'post_code' => $order->billing_postcode,
         'home_phone' => $order->billing_phone
         );
 
@@ -718,11 +718,11 @@ function fz_init() {
         }
 
         $data[] = array(
-          'product_code' => (string)$product->id, 
-          'sku' => $product->sku, 
-          'description' => $name, 
-          'qty' => $item['qty'], 
-          'cost' => $product->get_price(), 
+          'product_code' => (string)$product->id,
+          'sku' => $product->sku,
+          'description' => $name,
+          'qty' => $item['qty'],
+          'cost' => $product->get_price(),
           'line_total' => $order->get_line_subtotal($item)
           );
       }
@@ -735,14 +735,14 @@ function fz_init() {
      */
     function get_fraud_shipping($order) {
       $data = array(
-      'first_name' => $order->shipping_first_name, 
-      'last_name' => $order->shipping_last_name, 
-      'email' => $order->shipping_email, 
-      'address_1' => $order->shipping_address_1, 
-      'address_2' => $order->shipping_address_2, 
-      'city' => $order->shipping_city, 
-      'country' => $this->country_map[$order->shipping_country], 
-      'post_code' => $order->shipping_postcode, 
+      'first_name' => $order->shipping_first_name,
+      'last_name' => $order->shipping_last_name,
+      'email' => $order->shipping_email,
+      'address_1' => $order->shipping_address_1,
+      'address_2' => $order->shipping_address_2,
+      'city' => $order->shipping_city,
+      'country' => $this->country_map[$order->shipping_country],
+      'post_code' => $order->shipping_postcode,
       'shipping_method' => 'low_cost' // TODO: Shipping Method Map
       );
 
@@ -848,7 +848,7 @@ function fz_init() {
 
   function fz_customize_woocommerce_states() {
     global $states;
- 
+
     $states['AU'] = array(
         'ACT' => __( 'ACT', 'woocommerce' ),
         'NSW' => __( 'NSW', 'woocommerce' ),

--- a/class-wc-fatzebra.php
+++ b/class-wc-fatzebra.php
@@ -4,7 +4,7 @@
 Plugin Name: WooCommerce Fat Zebra Gateway
 Plugin URI: https://www.fatzebra.com.au/support/supported-carts
 Description: Extends WooCommerce with Fat Zebra payment gateway along with WooCommerce subscriptions support.
-Version: 1.5.4
+Version: 1.5.5
 Author: Fat Zebra
 Author URI: https://www.fatzebra.com.au
 */
@@ -58,7 +58,7 @@ function fz_init() {
       $this->icon = apply_filters('woocommerce_fatzebra_icon', '');
       $this->has_fields = true;
       $this->method_title = __('Fat Zebra', 'woocommerce');
-      $this->version = "1.5.2";
+      $this->version = "1.5.5";
 
       $this->api_version = "1.0";
       $this->live_url = "https://gateway.fatzebra.com.au/v{$this->api_version}/purchases";

--- a/images/fatzebra.js
+++ b/images/fatzebra.js
@@ -20,6 +20,10 @@ var zjscb = function(data) {
   }
 }
 
+jQuery('form.checkout').on('change', '#fatzebra-cc-form input[type=text]', function() {
+  jQuery('#fatzebra-token').val('');
+});
+
 jQuery("form.checkout").bind("checkout_place_order_fatzebra", function(e) {
   var $form = jQuery(this);
   if (jQuery("#fatzebra-token").val().length !== 0) return true;

--- a/readme.txt
+++ b/readme.txt
@@ -72,13 +72,13 @@ You should now be able to test the purchases via Fat Zebra.
 * Added help icon for security code
 * Removed style for logo and added CSS in style block to allow for override.
 
-= 1.3.4 = 
+= 1.3.4 =
 * Fixed lazy PHP tag (<?) causing issues in PHP 5.3.3
 
 = 1.3.5 =
 * Fixed support for 2.0 and tested on both 2.0 and 1.6
 
-= 1.3.6 = 
+= 1.3.6 =
 * Updated supports attributes to allow for amount changes, removing the notification when viewing/editing an order.
 
 = 1.4.0 =
@@ -121,6 +121,10 @@ You should now be able to test the purchases via Fat Zebra.
 
 = 1.5.4 =
 * Updated reference prefix used during testing
+
+= 1.5.5 =
+* Fix incorrect field breaking Direct Post (As per https://wordpress.org/support/topic/bug-152-breaks-direct-post)
+* Empty Credit Card Token when Credit Card details are modified, fixes problem where subsequent payment attempts with a new credit card continue to use the original tokenized card, even if original card has been declined
 
 == Support ==
 


### PR DESCRIPTION
Fix two major bugs with Direct Post payments:
- Fix incorrect field breaking Direct Post (As per https://wordpress.org/support/topic/bug-152-breaks-direct-post)
- Empty Credit Card Token when Credit Card details are modified, fixes problem where subsequent payment attempts with a new credit card continue to use the original tokenized card, even if original card has been declined
